### PR TITLE
fixed bug. truck details now render upon redirect after add truck

### DIFF
--- a/src/components/admin/AddTruck.js
+++ b/src/components/admin/AddTruck.js
@@ -37,7 +37,9 @@ class AddTruck extends Component {
     event.preventDefault();
     const truck = this.state;
     addTruck(truck)
-      .then(id => this.props.history.push(ROUTES.TRUCK.linkTo(id)));
+      .then(document => {
+        this.props.history.push(ROUTES.TRUCK.linkTo(document.id));
+      });
   };
 
   render() {


### PR DESCRIPTION
This pull request closes #40.

Description of changes:
changed addTruck handleSubmit redirect to include document.id instead of id. 